### PR TITLE
Add feature to create "Termin" appointments

### DIFF
--- a/TerminiAPI/Controllers/TerminController.cs
+++ b/TerminiAPI/Controllers/TerminController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using TerminiAPI.ViewModels;
 using TerminiService.TerminService;
+using TerminiService.TerminService.Dtos;
 using TerminiService.TerminService.Models;
 
 namespace TerminiAPI.Controllers
@@ -56,6 +58,38 @@ namespace TerminiAPI.Controllers
 				return BadRequest(response.Message);
 
 			return Ok(response);
+		}
+
+		[HttpPost("CreateTermin")]
+		[ProducesResponseType(typeof(CreateTerminResponse), StatusCodes.Status200OK)]
+		[ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+		[ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
+		public async Task<ActionResult<CreateTerminResponse>> CreateTermin([FromBody] CreateTerminViewModel createTerminViewModel)
+		{
+			if (createTerminViewModel != null)
+			{
+				CreateTerminDto createTermin = new CreateTerminDto()
+				{
+					ScheduleDate = createTerminViewModel.ScheduleDate,
+					StartTime = createTerminViewModel.StartTime,
+					DurationMinutes = createTerminViewModel.DurationMinutes,
+					Players = createTerminViewModel.Players
+				};
+
+				CreateTerminRequest request = new CreateTerminRequest();
+				request.CreateTermin = createTermin;
+
+				CreateTerminResponse response = await _terminService.CreateTermin(request);
+
+				if (!response.Success)
+					return BadRequest(response.Message);
+
+				return Ok(response);
+			}
+			else
+			{
+				return BadRequest("CreateTerminViewModel is null.");
+			}
 		}
 
 		#endregion

--- a/TerminiAPI/ViewModels/CreateTerminViewModel.cs
+++ b/TerminiAPI/ViewModels/CreateTerminViewModel.cs
@@ -1,0 +1,12 @@
+﻿using TerminiService.PlayerService.Dtos;
+
+namespace TerminiAPI.ViewModels
+{
+	public class CreateTerminViewModel
+	{
+		public DateOnly ScheduleDate { get; set; }
+		public TimeOnly StartTime { get; set; }
+		public int DurationMinutes { get; set; }
+		public List<PlayerDto> Players { get; set; } = new List<PlayerDto>();
+	}
+}

--- a/TerminiService/TerminService/Dtos/CreateTerminDto.cs
+++ b/TerminiService/TerminService/Dtos/CreateTerminDto.cs
@@ -1,0 +1,12 @@
+﻿using TerminiService.PlayerService.Dtos;
+
+namespace TerminiService.TerminService.Dtos
+{
+	public class CreateTerminDto
+	{
+		public DateOnly ScheduleDate { get; set; }
+		public TimeOnly StartTime { get; set; }
+		public int DurationMinutes { get; set; }
+		public List<PlayerDto> Players { get; set; } = new List<PlayerDto>();
+	}
+}

--- a/TerminiService/TerminService/Dtos/TerminDto.cs
+++ b/TerminiService/TerminService/Dtos/TerminDto.cs
@@ -9,6 +9,7 @@ namespace TerminiService.TerminService.Dtos
 		public DateTime DateCreated { get; set; }
 		public DateOnly ScheduledDate { get; set; }
 		public TimeOnly StartTime { get; set; }
+		public int DurationMinutes { get; set; }
 		public IEnumerable<PlayerDto>? Players { get; set; } = new List<PlayerDto>();
 	}
 }

--- a/TerminiService/TerminService/ITerminService.cs
+++ b/TerminiService/TerminService/ITerminService.cs
@@ -6,5 +6,6 @@ namespace TerminiService.TerminService
 	{
 		Task<GetTerminByIdResponse> GetTerminById(GetTerminByIdRequest request);
 		Task<GetTerminsResponse> GetTermins(GetTerminsRequest request);
+		Task<CreateTerminResponse> CreateTermin(CreateTerminRequest request);
 	}
 }

--- a/TerminiService/TerminService/Models/CreateTermin.cs
+++ b/TerminiService/TerminService/Models/CreateTermin.cs
@@ -1,0 +1,15 @@
+﻿using TerminiDomain.Core;
+using TerminiService.TerminService.Dtos;
+
+namespace TerminiService.TerminService.Models
+{
+	public class CreateTerminRequest : RequestBase
+	{
+		public CreateTerminDto CreateTermin { get; set; } = new CreateTerminDto();
+	}
+
+	public class CreateTerminResponse : ResponseBase<CreateTerminRequest>
+	{
+		public TerminDto? Termin { get; set; } = new TerminDto();
+	}
+}

--- a/TerminiWeb.Infrastructure/TerminService/Dtos/TerminDto.cs
+++ b/TerminiWeb.Infrastructure/TerminService/Dtos/TerminDto.cs
@@ -9,6 +9,7 @@ namespace TerminiWeb.Infrastructure.TerminService.Dtos
 		public DateTime DateCreated { get; set; }
 		public DateOnly ScheduledDate { get; set; }
 		public TimeOnly StartTime { get; set; }
+		public int DurationMinutes { get; set; }
 		public IEnumerable<PlayerDto>? Players { get; set; } = new List<PlayerDto>();
 	}
 }


### PR DESCRIPTION
Add feature to create "Termin" appointments

This commit introduces a new feature for creating "Termin" (appointment) in the application. A new HTTP POST endpoint `CreateTermin` is added in `TerminController.cs`, which accepts a `CreateTerminViewModel` and processes it through the service layer.

The `ITerminService` interface is updated with a method for creating a termin, returning a `CreateTerminResponse`. The `TerminService.cs` file implements the logic for creating a new termin, including database operations and player management.

New classes `CreateTerminDto`, `CreateTerminRequest`, and `CreateTerminResponse` are introduced to encapsulate the data and structure the response. Additionally, the `CreateTerminViewModel` class is added for data transfer from the client.

The `DurationMinutes` property is added to both `TerminDto` and `CreateTerminDto` to track the duration of the termin. These changes enhance the application's functionality by allowing users to create appointments with associated players effectively.