### PR TITLE
Added the Termins page feature so the frontend is nicely connected to the backend now

### DIFF
--- a/TerminiService/PlayerService/Dtos/PlayerDto.cs
+++ b/TerminiService/PlayerService/Dtos/PlayerDto.cs
@@ -5,9 +5,9 @@
 		public int Id { get; set; }
 		public bool Active { get; set; }
 		public DateTime DateCreated { get; set; }
-		public string Name { get; set; } = string.Empty;
-		public string Surname { get; set; } = string.Empty;
-		public string Sex { get; set; } = string.Empty;
-		public string Foot { get; set; } = string.Empty;
+		public string? Name { get; set; } = string.Empty;
+		public string? Surname { get; set; } = string.Empty;
+		public string? Sex { get; set; } = string.Empty;
+		public string? Foot { get; set; } = string.Empty;
 	}
 }

--- a/TerminiWeb/Components/Common/DataGrid.razor
+++ b/TerminiWeb/Components/Common/DataGrid.razor
@@ -21,6 +21,13 @@
 						</div>
 					</th>
 				}
+				else
+				{
+					<th scope="col" style="width: 40px;">
+						<div class="form-check">
+						</div>
+					</th>
+				}
 				@if (Columns != null)
 				{
 					@foreach (var column in Columns)

--- a/TerminiWeb/Components/Layout/NavMenu.razor
+++ b/TerminiWeb/Components/Layout/NavMenu.razor
@@ -3,5 +3,5 @@
 	<MudNavLink Href="counter" Match="NavLinkMatch.Prefix">Counter</MudNavLink>
 	<MudNavLink Href="weather" Match="NavLinkMatch.Prefix">Weather</MudNavLink>
 	<MudNavLink Href="players" Match="NavLinkMatch.Prefix">Players</MudNavLink>
-	<MudNavLink Href="tabs" Match="NavLinkMatch.Prefix">Tabs</MudNavLink>
+	<MudNavLink Href="termins" Match="NavLinkMatch.Prefix">Termins</MudNavLink>
 </MudNavMenu>

--- a/TerminiWeb/Components/Pages/Players.razor
+++ b/TerminiWeb/Components/Pages/Players.razor
@@ -8,67 +8,6 @@
 }
 else
 {
-	<MudText HtmlTag="span">Item: @_selectedItemText</MudText>
-	<MudText>Selected items @(_selectedPlayer != null ? 1 : 0): @(_selectedPlayer == null ? "" : _selectedItemText)</MudText>
-
-	<MudTable @ref="_table" T="PlayerDto" Items="@_players" MultiSelection="true" Hover="true"
-			  @bind-SelectedItem="@_selectedPlayer" @bind-SelectedItems="@_selectedItems" OnRowClick="@OnRowClick" SelectOnRowClick="@_selectOnRowClick"
-			  RowsPerPage="@_pageSize" CurrentPage="@_pageNumber" CurrentPageChanged="CurrentPageNumberChanged" RowsPerPageChanged="CurrentPageSizeChanged"
-			  Filter="new Func<PlayerDto, bool>(FilterFunction)">
-
-		<ToolBarContent>
-			<MudText Typo="Typo.h6">Players list</MudText>
-			<MudSpacer />
-			<MudTextField T="string" ValueChanged="@(s => OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start"
-						  AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Class="mt-0"></MudTextField>
-		</ToolBarContent>
-
-		<HeaderContent>
-			<MudTh>Name</MudTh>
-			<MudTh>Surname</MudTh>
-			<MudTh>Sex</MudTh>
-			<MudTh>Foot</MudTh>
-		</HeaderContent>
-
-		<RowTemplate>
-			<MudTd DataLabel="Name">@context.Name</MudTd>
-			<MudTd DataLabel="Surname">@context.Surname</MudTd>
-			<MudTd DataLabel="Sex">@context.Sex</MudTd>
-			<MudTd DataLabel="Foot">@context.Foot</MudTd>
-		</RowTemplate>
-
-		<NoRecordsContent>
-			<MudText>No matching records found</MudText>
-		</NoRecordsContent>
-
-		<LoadingContent>
-			<MudText>Loading...</MudText>
-		</LoadingContent>
-
-		<PagerContent>
-			<MudTablePager PageSizeOptions="new int[] { 1, 2, 5, 10, 25, 50, 100 }" />
-		</PagerContent>
-
-		<FooterContent>
-			<MudTd colspan="5">Select All</MudTd>
-		</FooterContent>
-
-	</MudTable>
-
-	if (_selectedPlayer != null)
-	{
-		<MudPaper Class="pa-4 mt-4">
-			<MudText Typo="Typo.h6">Selected Item</MudText>
-			<MudItem>@($"Name: {_selectedPlayer.Name} => Surname: {_selectedPlayer.Surname}")</MudItem>
-		</MudPaper>
-	}
-	else
-	{
-		<MudText Typo="Typo.h6"> No Item was selected! </MudText>
-	}
-
-	<MudText HtmlTag="span">Selected items: @(_selectedItems == null ? "" : string.Join(", ", _selectedItems.OrderBy(x => x.Id).Select(x => $"{x.Name} {x.Surname}")))</MudText>
-
 	<DropDown T="PlayerDto"
 			  Items="@_players"
 			  DisplayProperty="FullName"
@@ -112,6 +51,5 @@ else
 				</ContextMenu>
 			</Template>
 		</GridColumn>
-
 	</DataGrid>
 }

--- a/TerminiWeb/Components/Pages/Players.razor.cs
+++ b/TerminiWeb/Components/Pages/Players.razor.cs
@@ -16,14 +16,6 @@ namespace TerminiWeb.Components.Pages
 		private IEnumerable<PlayerDto> _players;
 		private int _pageSize = 5;
 		private int _pageNumber = 1;
-		private int _totalItems;
-		private string _searchString = null;
-		private PlayerDto? _selectedPlayer;
-
-		private bool _selectOnRowClick = true;
-		private MudTable<PlayerDto>? _table;
-		private string _selectedItemText = "No row clicked";
-		private HashSet<PlayerDto>? _selectedItems;
 		private int[] _pageSizeOptions = new int[] { 5, 10, 20 };
 		private PlayerFilterModel _filterModel = new PlayerFilterModel();
 
@@ -69,66 +61,21 @@ namespace TerminiWeb.Components.Pages
 				if (response != null && response.Players != null && response.Players.Any())
 				{
 					_players = response.Players;
-					_totalItems = _players.Count();
 				}
 			}
 			catch (Exception ex)
 			{
-				_logger.LogError(ex, "Players.razor.cs.GetPlayers() - Exception message: {Message}", ex.Message);
+				_logger?.LogError(ex, "Players.razor.cs.GetPlayers() - Exception message: {Message}", ex.Message);
 				return false;
 			}
 
 			return true;
 		}
 
-		private void CurrentPageNumberChanged(int page)
-		{
-			_pageNumber = page;
-		}
-
-		private void CurrentPageSizeChanged(int size)
-		{
-			_pageSize = size;
-		}
-
 		private async Task FilteredSearch()
 		{
 			await GetPlayers(_filterModel);
 			StateHasChanged();
-		}
-
-		void OnRowClick(TableRowClickEventArgs<PlayerDto> args)
-		{
-			if (args.Item != null)
-			{
-				_selectedItemText = $"{args.Item.Name} {args.Item.Surname}";
-			}
-		}
-
-		private void OnSearch(string text)
-		{
-			_searchString = text;
-
-			if (_table != null)
-				_table.ReloadServerData();
-		}
-
-		private bool FilterFunction(PlayerDto player) => FilterFunc(player, _searchString);
-
-		private bool FilterFunc(PlayerDto player, string searchString)
-		{
-			if (string.IsNullOrEmpty(searchString))
-				return true;
-			if (player.Name.ToString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
-				return true;
-			if (player.Surname.ToString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
-				return true;
-			if (player.Sex.ToString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
-				return true;
-			if (player.Foot.ToString().Contains(searchString, StringComparison.OrdinalIgnoreCase))
-				return true;
-
-			return false;
 		}
 
 		public void OnSelectedItemChanged(PlayerDto item)

--- a/TerminiWeb/Components/Pages/Termins.razor
+++ b/TerminiWeb/Components/Pages/Termins.razor
@@ -1,0 +1,37 @@
+﻿@page "/termins"
+
+@using TerminiWeb.Infrastructure.PlayerService.Dtos
+@using TerminiWeb.Infrastructure.TerminService.Dtos
+@using TerminiWeb.Components.Common
+
+@if (_termins == null)
+{
+	<LoadIndicator />
+}
+else
+{
+	<DataGrid TItem="TerminDto"
+			  Items="@_termins"
+			  Sortable="true"
+			  PageSizeOptions="@_pageSizeOptions"
+			  PageNumber="@_pageNumber"
+			  PageSize="@_pageSize"
+			  Filterable="true"
+			  FilterModel="@_filterModel"
+			  OnSearch="@FilteredSearch"
+			  RowSelectionIdentifierProperty="Id"
+			  EnableRowSelection="true">
+		<GridColumn TItem="TerminDto" Property="ScheduledDate" Caption="Scheduled Date" Sortable="false" Filterable="true" FilterModelProperty="ScheduledDateFilter" />
+		<GridColumn TItem="TerminDto" Property="StartTime" Caption="Start Time" Sortable="false" Filterable="true" FilterModelProperty="StartTimeFilter" />
+		<GridColumn TItem="TerminDto" Property="DurationMinutes" Caption="Duration (min)" Sortable="true" Filterable="true" FilterModelProperty="DurationMinutesFilter" />
+		<GridColumn TItem="TerminDto" Sortable="false" Alignment="Common.Enumerators.AlignOption.Right">
+			<Template Context="termin">
+				<ContextMenu>
+					<ContextMenuItem Text="Edit" OnClick="async () => await EditTermin(termin)" />
+					<ContextMenuItem Text="Delete" OnClick="async () => await DeleteTermin(termin)" />
+					<ContextMenuItem Text="View" OnClick="async () => await ViewTermin(termin)" />
+				</ContextMenu>
+			</Template>
+		</GridColumn>
+	</DataGrid>
+}

--- a/TerminiWeb/Components/Pages/Termins.razor.cs
+++ b/TerminiWeb/Components/Pages/Termins.razor.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.AspNetCore.Components;
+using MudBlazor;
+using TerminiWeb.FilterModels;
+using TerminiWeb.Infrastructure.TerminService;
+using TerminiWeb.Infrastructure.TerminService.Dtos;
+using TerminiWeb.Infrastructure.TerminService.Models;
+
+namespace TerminiWeb.Components.Pages
+{
+	public partial class Termins : ComponentBase
+	{
+		#region Injections
+
+		[Inject]
+		private ITerminService? _terminService { get; set; }
+
+		[Inject]
+		private ILogger<Players>? _logger { get; set; }
+
+		[Inject] IDialogService? _dialogService { get; set; }
+
+		#endregion
+
+		#region Fields
+
+		private bool firstLoad = true;
+		private IEnumerable<TerminDto>? _termins;
+		private int _pageSize = 5;
+		private int _pageNumber = 1;
+		private int[] _pageSizeOptions = new int[] { 5, 10, 20 };
+		private TerminFilterModel _filterModel = new TerminFilterModel();
+
+		#endregion
+
+		#region Methods
+
+		protected override async Task OnInitializedAsync()
+		{
+			if (firstLoad)
+			{
+				bool isLoaded = await GetTermins(_filterModel);
+				firstLoad = false;
+				StateHasChanged();
+			}
+
+			await base.OnInitializedAsync();
+		}
+
+		private async Task<bool> GetTermins(TerminFilterModel filter)
+		{
+			GetTerminsRequest request = new GetTerminsRequest();
+			//request.Name = filter.Name;
+			//request.Surname = filter.Surname;
+			//request.FullName = filter.FullName;
+
+			try
+			{
+				GetTerminsResponse response = await _terminService.GetTermins(request);
+
+				if (response != null && response.Termins != null && response.Termins.Any())
+				{
+					_termins = response.Termins;
+				}
+				else
+				{
+					_termins = new List<TerminDto>();
+				}
+			}
+			catch (Exception ex)
+			{
+				_logger?.LogError(ex, "Termins.razor.cs.GetTermins() - Exception message: {Message}", ex.Message);
+				return false;
+			}
+
+			return true;
+		}
+
+		private async Task FilteredSearch()
+		{
+			await GetTermins(_filterModel);
+			StateHasChanged();
+		}
+
+		private async Task EditTermin(TerminDto data)
+		{
+			try
+			{
+				Console.WriteLine(data);
+				Console.WriteLine("Edit termin {0}", data?.Id.ToString() ?? string.Empty);
+			}
+			catch (Exception ex)
+			{
+				if (_logger != null)
+					_logger.LogError($"Error in EditTermin: {ex.Message}", ex);
+
+				throw;
+			}
+
+			await InvokeAsync(StateHasChanged);
+		}
+
+		private async Task DeleteTermin(TerminDto data)
+		{
+			Console.WriteLine("Delete termin {0}", data?.Id.ToString() ?? string.Empty);
+			await InvokeAsync(StateHasChanged);
+		}
+
+		private async Task ViewTermin(TerminDto data)
+		{
+			Console.WriteLine("View termin {0} ", data?.Id.ToString() ?? string.Empty);
+			await InvokeAsync(StateHasChanged);
+		}
+
+		#endregion
+	}
+}

--- a/TerminiWeb/FilterModels/TerminFilterModel.cs
+++ b/TerminiWeb/FilterModels/TerminFilterModel.cs
@@ -1,0 +1,9 @@
+﻿namespace TerminiWeb.FilterModels
+{
+	public class TerminFilterModel
+	{
+		public DateOnly? ScheduledDateFilter { get; set; }
+		public TimeOnly? StartTimeFilter { get; set; }
+		public int? DurationMinutesFilter { get; set; }
+	}
+}


### PR DESCRIPTION
Added the Termins page feature so the frontend is nicely connected to the backend now

Refactor player and termin data handling

- Updated PlayerDto to use nullable properties for Name, Surname, Sex, and Foot.
- Migrated TerminService to use Entity Framework Core, enhancing data fetching with related entities.
- Improved DataGrid.razor with conditional rendering for empty selections.
- Replaced "Tabs" link with "Termins" in NavMenu.razor.
- Streamlined Players.razor by removing unnecessary UI elements and bindings.
- Cleaned up Players.razor.cs by removing fields and methods related to player selection and filtering.
- Introduced Termins.razor for displaying termin data with a new data grid.
- Created Termins.razor.cs to manage termin data logic and user interactions.
- Added TerminFilterModel.cs for filtering termin data based on scheduled date, start time, and duration.