### PR TITLE
Added a rating column on the player entity and playerRating on the termin.players entity so you can add a rating to the player that played on a termin and then it will calculate an overall rating added to the player entity depending on all ratings that player has had in termins

### DIFF
--- a/TerminiDataAccess/TerminiContext/Compiled/PlayerEntityType.cs
+++ b/TerminiDataAccess/TerminiContext/Compiled/PlayerEntityType.cs
@@ -19,7 +19,7 @@ namespace TerminiDataAccess.TerminiContext
                 "TerminiDataAccess.TerminiContext.Models.Player",
                 typeof(Player),
                 baseEntityType,
-                propertyCount: 7,
+                propertyCount: 8,
                 navigationCount: 1,
                 keyCount: 1);
 
@@ -73,6 +73,14 @@ namespace TerminiDataAccess.TerminiContext
                 maxLength: 255,
                 unicode: false);
             name.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
+
+            var rating = runtimeEntityType.AddProperty(
+                "Rating",
+                typeof(int?),
+                propertyInfo: typeof(Player).GetProperty("Rating", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                fieldInfo: typeof(Player).GetField("<Rating>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                nullable: true);
+            rating.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
 
             var sex = runtimeEntityType.AddProperty(
                 "Sex",

--- a/TerminiDataAccess/TerminiContext/Compiled/TerminEntityType.cs
+++ b/TerminiDataAccess/TerminiContext/Compiled/TerminEntityType.cs
@@ -19,7 +19,7 @@ namespace TerminiDataAccess.TerminiContext
                 "TerminiDataAccess.TerminiContext.Models.Termin",
                 typeof(Termin),
                 baseEntityType,
-                propertyCount: 6,
+                propertyCount: 7,
                 navigationCount: 1,
                 namedIndexCount: 1,
                 keyCount: 1);
@@ -62,6 +62,14 @@ namespace TerminiDataAccess.TerminiContext
                 fieldInfo: typeof(Termin).GetField("<DurationMinutes>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
                 sentinel: 0);
             durationMinutes.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
+
+            var isFinished = runtimeEntityType.AddProperty(
+                "IsFinished",
+                typeof(bool?),
+                propertyInfo: typeof(Termin).GetProperty("IsFinished", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                fieldInfo: typeof(Termin).GetField("<IsFinished>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                nullable: true);
+            isFinished.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
 
             var scheduledDate = runtimeEntityType.AddProperty(
                 "ScheduledDate",

--- a/TerminiDataAccess/TerminiContext/Compiled/TerminPlayersEntityType.cs
+++ b/TerminiDataAccess/TerminiContext/Compiled/TerminPlayersEntityType.cs
@@ -20,7 +20,7 @@ namespace TerminiDataAccess.TerminiContext
                 "TerminiDataAccess.TerminiContext.Models.TerminPlayers",
                 typeof(TerminPlayers),
                 baseEntityType,
-                propertyCount: 5,
+                propertyCount: 6,
                 navigationCount: 2,
                 foreignKeyCount: 2,
                 namedIndexCount: 3,
@@ -64,6 +64,14 @@ namespace TerminiDataAccess.TerminiContext
                 fieldInfo: typeof(TerminPlayers).GetField("<PlayerId>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
                 sentinel: 0);
             playerId.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
+
+            var playerRating = runtimeEntityType.AddProperty(
+                "PlayerRating",
+                typeof(int?),
+                propertyInfo: typeof(TerminPlayers).GetProperty("PlayerRating", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                fieldInfo: typeof(TerminPlayers).GetField("<PlayerRating>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+                nullable: true);
+            playerRating.AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.None);
 
             var terminId = runtimeEntityType.AddProperty(
                 "TerminId",

--- a/TerminiDataAccess/TerminiContext/Compiled/TerminiContextModelBuilder.cs
+++ b/TerminiDataAccess/TerminiContext/Compiled/TerminiContextModelBuilder.cs
@@ -11,7 +11,7 @@ namespace TerminiDataAccess.TerminiContext
     public partial class TerminiContextModel
     {
         private TerminiContextModel()
-            : base(skipDetectChanges: false, modelId: new Guid("005e9d14-aa31-4304-b5c4-bfbd234c9d32"), entityTypeCount: 3)
+            : base(skipDetectChanges: false, modelId: new Guid("aa6d3f25-a2f4-40fa-9141-dc14a2e0fb00"), entityTypeCount: 3)
         {
         }
 
@@ -28,7 +28,7 @@ namespace TerminiDataAccess.TerminiContext
             TerminEntityType.CreateAnnotations(termin);
             TerminPlayersEntityType.CreateAnnotations(terminPlayers);
 
-            AddAnnotation("ProductVersion", "9.0.2");
+            AddAnnotation("ProductVersion", "9.0.4");
             AddAnnotation("Relational:MaxIdentifierLength", 128);
             AddAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
         }

--- a/TerminiDataAccess/TerminiContext/Models/Player.cs
+++ b/TerminiDataAccess/TerminiContext/Models/Player.cs
@@ -19,5 +19,7 @@ public partial class Player
 
     public string? Sex { get; set; }
 
+    public int? Rating { get; set; }
+
     public virtual ICollection<TerminPlayers> TerminPlayers { get; set; } = new List<TerminPlayers>();
 }

--- a/TerminiDataAccess/TerminiContext/Models/Termin.cs
+++ b/TerminiDataAccess/TerminiContext/Models/Termin.cs
@@ -17,5 +17,7 @@ public partial class Termin
 
     public int DurationMinutes { get; set; }
 
+    public bool? IsFinished { get; set; }
+
     public virtual ICollection<TerminPlayers> TerminPlayers { get; set; } = new List<TerminPlayers>();
 }

--- a/TerminiDataAccess/TerminiContext/Models/TerminPlayers.cs
+++ b/TerminiDataAccess/TerminiContext/Models/TerminPlayers.cs
@@ -15,6 +15,8 @@ public partial class TerminPlayers
 
     public int PlayerId { get; set; }
 
+    public int? PlayerRating { get; set; }
+
     public virtual Player Player { get; set; } = null!;
 
     public virtual Termin Termin { get; set; } = null!;

--- a/TerminiDatabase/Termini/Tables/Player.sql
+++ b/TerminiDatabase/Termini/Tables/Player.sql
@@ -6,6 +6,7 @@
     [Surname]     VARCHAR (255) NULL,
     [Foot]        VARCHAR (5)   NULL,
     [Sex]         VARCHAR (6)   NULL,
+    [Rating]      INT           NULL,
     CONSTRAINT [PK_Termini_Player_Id] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
 

--- a/TerminiDatabase/Termini/Tables/Termin.Players.sql
+++ b/TerminiDatabase/Termini/Tables/Termin.Players.sql
@@ -1,13 +1,16 @@
 ﻿CREATE TABLE [Termini].[Termin.Players] (
-    [Id]          INT      IDENTITY (1, 1) NOT NULL,
-    [Active]      BIT      CONSTRAINT [DF_Termini_Termin_Players_Active] DEFAULT ((1)) NOT NULL,
-    [DateCreated] DATETIME CONSTRAINT [DF_Termini_Termin_Players_DateCreated] DEFAULT (getdate()) NOT NULL,
-    [TerminId]    INT      NOT NULL,
-    [PlayerId]    INT      NOT NULL,
+    [Id]           INT      IDENTITY (1, 1) NOT NULL,
+    [Active]       BIT      CONSTRAINT [DF_Termini_Termin_Players_Active] DEFAULT ((1)) NOT NULL,
+    [DateCreated]  DATETIME CONSTRAINT [DF_Termini_Termin_Players_DateCreated] DEFAULT (getdate()) NOT NULL,
+    [TerminId]     INT      NOT NULL,
+    [PlayerId]     INT      NOT NULL,
+    [PlayerRating] INT      NULL,
     CONSTRAINT [PK_Termini_Termin_Players_Id] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_Termini_Termin_Players_PlayerId] FOREIGN KEY ([PlayerId]) REFERENCES [Termini].[Player] ([Id]),
     CONSTRAINT [FK_Termini_Termin_Players_TerminId] FOREIGN KEY ([TerminId]) REFERENCES [Termini].[Termin] ([Id])
 );
+
+
 
 
 GO

--- a/TerminiDatabase/Termini/Tables/Termin.sql
+++ b/TerminiDatabase/Termini/Tables/Termin.sql
@@ -5,8 +5,11 @@
     [ScheduledDate]   DATE     NOT NULL,
     [StartTime]       TIME (7) NOT NULL,
     [DurationMinutes] INT      NOT NULL,
+    [IsFinished]      BIT      NULL,
     CONSTRAINT [PK_Termini_Termin_Id] PRIMARY KEY CLUSTERED ([Id] ASC)
 );
+
+
 
 
 GO

--- a/TerminiService/PlayerService/Dtos/PlayerDto.cs
+++ b/TerminiService/PlayerService/Dtos/PlayerDto.cs
@@ -9,5 +9,6 @@
 		public string? Surname { get; set; } = string.Empty;
 		public string? Sex { get; set; } = string.Empty;
 		public string? Foot { get; set; } = string.Empty;
+		public int? Rating { get; set; }
 	}
 }

--- a/TerminiService/PlayerService/Models/GetPlayers.cs
+++ b/TerminiService/PlayerService/Models/GetPlayers.cs
@@ -8,6 +8,7 @@ namespace TerminiService.PlayerService.Models
 		public string Name { get; set; } = string.Empty;
 		public string Surname { get; set; } = string.Empty;
 		public string FullName { get; set; } = string.Empty;
+		public int? PlayerRating { get; set; }
 	}
 
 	public class GetPlayersResponse : ResponseBase<GetPlayersRequest>

--- a/TerminiService/PlayerService/PlayerService.cs
+++ b/TerminiService/PlayerService/PlayerService.cs
@@ -57,6 +57,10 @@ namespace TerminiService.PlayerService
 								)
 							)
 						)
+						&&
+						(
+							request.PlayerRating == null || (p.Rating == request.PlayerRating)
+						)
 					)
 					.Select(p => new PlayerDto
 					{
@@ -66,7 +70,8 @@ namespace TerminiService.PlayerService
 						Name = p.Name ?? string.Empty,
 						Surname = p.Surname ?? string.Empty,
 						Sex = p.Sex ?? string.Empty,
-						Foot = p.Foot ?? string.Empty
+						Foot = p.Foot ?? string.Empty,
+						Rating = p.Rating
 					})
 					.TagWith("PlayerService.GetPlayersList")
 					.ToListAsync();

--- a/TerminiService/TerminService/Dtos/TerminDto.cs
+++ b/TerminiService/TerminService/Dtos/TerminDto.cs
@@ -10,6 +10,7 @@ namespace TerminiService.TerminService.Dtos
 		public DateOnly ScheduledDate { get; set; }
 		public TimeOnly StartTime { get; set; }
 		public int DurationMinutes { get; set; }
+		public bool? IsFinished { get; set; }
 		public IEnumerable<PlayerDto>? Players { get; set; } = new List<PlayerDto>();
 	}
 }

--- a/TerminiService/TerminService/TerminService.cs
+++ b/TerminiService/TerminService/TerminService.cs
@@ -50,6 +50,7 @@ namespace TerminiService.TerminService
 							ScheduledDate = x.ScheduledDate,
 							StartTime = x.StartTime,
 							DurationMinutes = x.DurationMinutes,
+							IsFinished = x.IsFinished,
 							Players = x.TerminPlayers
 								.Where(p => p.Active)
 								.Select(p => new PlayerDto()
@@ -60,7 +61,8 @@ namespace TerminiService.TerminService
 									Name = p.Player.Name ?? string.Empty,
 									Surname = p.Player.Surname ?? string.Empty,
 									Sex = p.Player.Sex ?? string.Empty,
-									Foot = p.Player.Foot ?? string.Empty
+									Foot = p.Player.Foot ?? string.Empty,
+									Rating = p.PlayerRating ?? p.Player.Rating
 								})
 						})
 						.FirstOrDefaultAsync();
@@ -115,6 +117,7 @@ namespace TerminiService.TerminService
 						ScheduledDate = x.ScheduledDate,
 						StartTime = x.StartTime,
 						DurationMinutes = x.DurationMinutes,
+						IsFinished = x.IsFinished,
 						Players = x.TerminPlayers
 							.Where(p => p.Active)
 							.Select(p => new PlayerDto()
@@ -125,7 +128,8 @@ namespace TerminiService.TerminService
 								Name = p.Player.Name ?? string.Empty,
 								Surname = p.Player.Surname ?? string.Empty,
 								Sex = p.Player.Sex ?? string.Empty,
-								Foot = p.Player.Foot ?? string.Empty
+								Foot = p.Player.Foot ?? string.Empty,
+								Rating = p.PlayerRating ?? p.Player.Rating
 							})
 					});
 

--- a/TerminiWeb.Infrastructure/PlayerService/Dtos/PlayerDto.cs
+++ b/TerminiWeb.Infrastructure/PlayerService/Dtos/PlayerDto.cs
@@ -9,6 +9,7 @@
 		public string Surname { get; set; } = string.Empty;
 		public string Sex { get; set; } = string.Empty;
 		public string Foot { get; set; } = string.Empty;
+		public int? Rating { get; set; }
 		public string FullName
 		{
 			get

--- a/TerminiWeb.Infrastructure/PlayerService/Models/GetPlayerList.cs
+++ b/TerminiWeb.Infrastructure/PlayerService/Models/GetPlayerList.cs
@@ -8,6 +8,7 @@ namespace TerminiWeb.Infrastructure.PlayerService.Models
 		public string Name { get; set; } = string.Empty;
 		public string Surname { get; set; } = string.Empty;
 		public string FullName { get; set; } = string.Empty;
+		public int? PlayerRating { get; set; }
 	}
 
 	public class GetPlayerListResponse : ResponseBase<GetPlayerListRequest>

--- a/TerminiWeb.Infrastructure/PlayerService/PlayerService.cs
+++ b/TerminiWeb.Infrastructure/PlayerService/PlayerService.cs
@@ -64,6 +64,9 @@ namespace TerminiWeb.Infrastructure.PlayerService
 					if (!string.IsNullOrEmpty(request.FullName))
 						queryParameters.Add($"fullName={Uri.EscapeDataString(request.FullName)}");
 
+					if (request.PlayerRating != null)
+						queryParameters.Add($"playerRating={request.PlayerRating}");
+
 					if (queryParameters.Any())
 						Apiurl += "?" + string.Join("&", queryParameters);
 

--- a/TerminiWeb.Infrastructure/TerminService/Dtos/TerminDto.cs
+++ b/TerminiWeb.Infrastructure/TerminService/Dtos/TerminDto.cs
@@ -10,6 +10,22 @@ namespace TerminiWeb.Infrastructure.TerminService.Dtos
 		public DateOnly ScheduledDate { get; set; }
 		public TimeOnly StartTime { get; set; }
 		public int DurationMinutes { get; set; }
+		public bool? IsFinished { get; set; }
 		public IEnumerable<PlayerDto>? Players { get; set; } = new List<PlayerDto>();
+		public bool WasPlayed
+		{
+			get
+			{
+				bool wasPlayed = false;
+
+				DateTime scheduleDateTime = new DateTime(ScheduledDate.Year, ScheduledDate.Month, ScheduledDate.Day, StartTime.Hour, StartTime.Minute, 0);
+				if (scheduleDateTime < DateTime.Now)
+				{
+					wasPlayed = true;
+				}
+
+				return wasPlayed;
+			}
+		}
 	}
 }

--- a/TerminiWeb/Components/Pages/Players.razor
+++ b/TerminiWeb/Components/Pages/Players.razor
@@ -41,7 +41,8 @@ else
 			  EnableRowSelection="true">
 		<GridColumn TItem="PlayerDto" Property="Name" Caption="Name" Sortable="false" Filterable="true" FilterModelProperty="Name" />
 		<GridColumn TItem="PlayerDto" Property="Surname" Caption="Surname" Sortable="false" Filterable="true" FilterModelProperty="Surname" />
-		<GridColumn TItem="PlayerDto" Property="FullName" Caption="FullName" Sortable="true" Filterable="true" FilterModelProperty="FullName" />
+		<GridColumn TItem="PlayerDto" Property="FullName" Caption="Full Name" Sortable="true" Filterable="true" FilterModelProperty="FullName" />
+		<GridColumn TItem="PlayerDto" Property="Rating" Caption="Player rating" Sortable="true" Filterable="true" FilterModelProperty="PlayerRating"></GridColumn>
 		<GridColumn TItem="PlayerDto" Sortable="false" Alignment="Common.Enumerators.AlignOption.Right">
 			<Template Context="player">
 				<ContextMenu>

--- a/TerminiWeb/Components/Pages/Players.razor.cs
+++ b/TerminiWeb/Components/Pages/Players.razor.cs
@@ -53,6 +53,7 @@ namespace TerminiWeb.Components.Pages
 			request.Name = filter.Name;
 			request.Surname = filter.Surname;
 			request.FullName = filter.FullName;
+			request.PlayerRating = filter.PlayerRating;
 
 			try
 			{

--- a/TerminiWeb/Components/Pages/Termins.razor
+++ b/TerminiWeb/Components/Pages/Termins.razor
@@ -30,6 +30,20 @@ else
 		<GridColumn TItem="TerminDto" Property="ScheduledDate" Caption="Scheduled Date" Sortable="false" Filterable="true" FilterModelProperty="ScheduledDateFilter" />
 		<GridColumn TItem="TerminDto" Property="StartTime" Caption="Start Time" Sortable="false" Filterable="true" FilterModelProperty="StartTimeFilter" />
 		<GridColumn TItem="TerminDto" Property="DurationMinutes" Caption="Duration (min)" Sortable="true" Filterable="true" FilterModelProperty="DurationMinutesFilter" />
+		<GridColumn TItem="TerminDto" Property="WasPlayed" Caption="" Sortable="false" Filterable="false">
+			<Template Context="termin">
+				<MudButton Disabled="@((termin.IsFinished != null && termin.IsFinished == true) || !termin.WasPlayed)" Color="Color.Primary" Variant="Variant.Text" OnClick="@(() => FinishTermin(termin))">
+					@if (termin.WasPlayed)
+					{
+						<i class="fas fa-check"></i>
+					}
+					else
+					{
+						<i class="fas fa-times"></i>
+					}
+				</MudButton>
+			</Template>
+		</GridColumn>
 		<GridColumn TItem="TerminDto" Sortable="false" Alignment="Common.Enumerators.AlignOption.Right">
 			<Template Context="termin">
 				<ContextMenu>

--- a/TerminiWeb/Components/Pages/Termins.razor.cs
+++ b/TerminiWeb/Components/Pages/Termins.razor.cs
@@ -17,7 +17,7 @@ namespace TerminiWeb.Components.Pages
 		[Inject]
 		private ILogger<Players>? _logger { get; set; }
 
-		[Inject] 
+		[Inject]
 		private IDialogService? _dialogService { get; set; }
 
 		[Inject]
@@ -112,6 +112,12 @@ namespace TerminiWeb.Components.Pages
 		private async Task ViewTermin(TerminDto data)
 		{
 			Console.WriteLine("View termin {0} ", data?.Id.ToString() ?? string.Empty);
+			await InvokeAsync(StateHasChanged);
+		}
+
+		private async Task FinishTermin(TerminDto data)
+		{
+			Console.WriteLine("Finish termin {0} ", data?.Id.ToString() ?? string.Empty);
 			await InvokeAsync(StateHasChanged);
 		}
 

--- a/TerminiWeb/FilterModels/PlayerFilterModel.cs
+++ b/TerminiWeb/FilterModels/PlayerFilterModel.cs
@@ -5,5 +5,6 @@
 		public string Name { get; set; } = string.Empty;
 		public string Surname { get; set; } = string.Empty;
 		public string FullName { get; set; } = string.Empty;
+		public int? PlayerRating { get; set; }
 	}
 }


### PR DESCRIPTION
Added a rating column on the player entity and playerRating on the termin.players entity so you can add a rating to the player that played on a termin and then it will calculate an overall rating added to the player entity depending on all ratings that player has had in termins

Add new properties and update model versions

- Increased property counts in Player, Termin, and TerminPlayers entity types.
- Added nullable properties: Rating (Player), IsFinished (Termin), and PlayerRating (TerminPlayers).
- Updated model ID and product version in TerminiContextModelBuilder.
- Modified Player, Termin, and TerminPlayers classes to include new properties.
- Updated SQL schema files to reflect new columns and constraints.
- Enhanced PlayerDto and GetPlayers to include new properties.
- Adjusted PlayerService and TerminService to process new properties.
- Updated UI in Players.razor and Termins.razor to display new properties.
- Added PlayerRating filter in PlayerFilterModel.
- Implemented FinishTermin method in Termins.razor.cs for UI state management.