### PR TITLE
Update NuGet packages across multiple projects

### DIFF
--- a/TerminiAPI/TerminiAPI.csproj
+++ b/TerminiAPI/TerminiAPI.csproj
@@ -8,17 +8,17 @@
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="EntityFramework" Version="6.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TerminiAdministration.AppHost/TerminiAdministration.AppHost.csproj
+++ b/TerminiAdministration.AppHost/TerminiAdministration.AppHost.csproj
@@ -9,7 +9,7 @@
     <UserSecretsId>739e983a-917e-4f71-aeca-ad81e6bfbd81</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
+     <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TerminiAPI\TerminiAPI.csproj" />

--- a/TerminiAdministration.ServiceDefaults/TerminiAdministration.ServiceDefaults.csproj
+++ b/TerminiAdministration.ServiceDefaults/TerminiAdministration.ServiceDefaults.csproj
@@ -10,13 +10,13 @@
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
-		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.2.0" />
-		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
-		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.1" />
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.5.0" />
+		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
 	</ItemGroup>
 
 </Project>

--- a/TerminiDataAccess/TerminiDataAccess.csproj
+++ b/TerminiDataAccess/TerminiDataAccess.csproj
@@ -8,16 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.5.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TerminiService/TerminiService.csproj
+++ b/TerminiService/TerminiService.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TerminiDataAccess\TerminiDataAccess.csproj" />

--- a/TerminiWeb.Infrastructure/TerminiWeb.Infrastructure.csproj
+++ b/TerminiWeb.Infrastructure/TerminiWeb.Infrastructure.csproj
@@ -9,10 +9,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TerminiDomain\TerminiDomain.csproj" />

--- a/TerminiWeb/TerminiWeb.csproj
+++ b/TerminiWeb/TerminiWeb.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -10,12 +10,12 @@
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="DropDownPackage" Version="1.0.2" />
     <PackageReference Include="MultiSelectPackage" Version="1.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
-    <PackageReference Include="MudBlazor" Version="8.5.1" />
-    <PackageReference Include="MudBlazor.Markdown" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
+    <PackageReference Include="MudBlazor" Version="8.6.0" />
+    <PackageReference Include="MudBlazor.Markdown" Version="8.6.0" />
     <PackageReference Include="MudBlazor.ThemeManager" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Update NuGet packages across multiple projects

Updated various NuGet package versions to their latest releases:
- `TerminiAPI.csproj`: Upgraded `Microsoft.EntityFrameworkCore` and `Microsoft.AspNetCore.OpenApi` from `9.0.4` to `9.0.5`.
- `TerminiAdministration.AppHost.csproj`: Updated `Aspire.Hosting.AppHost` from `9.2.0` to `9.3.0`.
- `TerminiAdministration.ServiceDefaults.csproj`: Upgraded OpenTelemetry and Microsoft.Extensions packages, with versions changing from `9.2.0` and `9.4.0` to `9.3.0` and `9.5.0`, and OpenTelemetry packages from `1.11.x` to `1.12.0`.
- `TerminiDataAccess.csproj`: Similar updates to `Microsoft.EntityFrameworkCore` packages from `9.0.4` to `9.0.5`.
- `TerminiService.csproj`: Updated `Serilog` from `4.2.0` to `4.3.0`.
- `TerminiWeb.Infrastructure.csproj`: Updated `Microsoft.Extensions.Options` from `9.0.4` to `9.0.5` and `Serilog` to `4.3.0`.
- `TerminiWeb.csproj`: Modified project SDK line and updated several package references from `9.0.4` to `9.0.5`, including `Microsoft.AspNetCore.Components.WebAssembly`, `Microsoft.Extensions.DependencyInjection`, and `MudBlazor` from `8.5.1` to `8.6.0`.