### PR TITLE
Update GrabaUIPackage to version 1.0.2

### DIFF
--- a/TerminiWeb/TerminiWeb.csproj
+++ b/TerminiWeb/TerminiWeb.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="GrabaUIPackage" Version="1.0.1" />
+    <PackageReference Include="GrabaUIPackage" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.5" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />


### PR DESCRIPTION
Update GrabaUIPackage to version 1.0.2

Updated the version of the `GrabaUIPackage` dependency in the `TerminiWeb.csproj` file from `1.0.1` to `1.0.2`.